### PR TITLE
Disable VibeD SSL mechanism

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -1,6 +1,9 @@
 name "dcms"
 description "dcms"
-authors "Dmitry Bubnenkov"
-copyright "Dmitry Bubnenkov"
-license "MIT"
+authors    "Dmitry Bubnenkov" "Pavel Chebotarev"
+copyright  "Dmitry Bubnenkov"
+license    "MIT"
+
 dependency "vibe-d" version="~>0.8.1"
+
+versions   "VibeNoSSL"

--- a/source/app.d
+++ b/source/app.d
@@ -10,7 +10,7 @@ void main()
 	bookText = readText("./book/book.md");
 	auto settings = new HTTPServerSettings;
 	settings.port = 8082;
-	settings.bindAddresses = ["::1", "127.0.0.1"];
+	settings.bindAddresses = ["127.0.0.1"];
 
 	auto router = new URLRouter;
 	router.get("*", serveStaticFiles("html/"));
@@ -34,5 +34,5 @@ void main()
 
 void data(HTTPServerRequest req, HTTPServerResponse res)
 {
-	res.writeJsonBody(answer);	
+	res.writeJsonBody(answer);
 }


### PR DESCRIPTION
SSL can be easily handled by nginx, so there is no need to support SSL by vibe.d side.